### PR TITLE
增加通过model切换讯飞版本，删除version字段

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,12 +73,13 @@ def chat_completion(
     X_API_SECRET: Annotated[Union[str, None],
                             Header(convert_underscores=False)] = None
 ):
-    version = chatCompletion.version
-    domain = get_domain(version)
-
+    
+    model = chatCompletion.model
     spark_client = None
-
-    if chatCompletion.model == 'vision':
+    version = model.split("-")[-1]  
+    domain = get_domain(version) 
+    
+    if model == 'vision':
         secrets = config_dict['vision']
 
         spark_client = SparkImage(

--- a/models/schema.py
+++ b/models/schema.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, validator
 from typing import Annotated, List, Union, Optional
 
-spark_model_versions = ['v1.1', 'v2.1', 'v3.1']
+spark_model_versions = ['spark-api-v1.1', 'spark-api-v2.1', 'spark-api-v3.1', 'vision']
 
 class MessageContentTextItem(BaseModel):
     type: str
@@ -28,9 +28,8 @@ class ChatCompletion(BaseModel):
     max_tokens: Optional[Union[int, None]] = 2048
     stream: Optional[bool] = False
     messages: List[Message] = []
-    model: Optional[str] = 'spark-api'
+    model: Optional[str] = 'spark-api-v3.1'
     n: Optional[int] = 1
-    version: Optional[Union[str, None]] = 'v1.1'
 
     @validator('max_tokens', pre=True, always=True)
     def set_max_tokens(cls, value):
@@ -38,13 +37,9 @@ class ChatCompletion(BaseModel):
             return 2048
         return value
 
-    @validator('version', pre=True, always=True)
-    def set_version(cls, value):
-        if value is None:
-            return 'v1.1'
-
-        if value not in spark_model_versions:
-            return 'v1.1'
-
+    @validator('model', pre=True, always=True)
+    def set_model(cls, value):
+        if value not in spark_model_versions or value is None:
+            return 'spark-api-v3.1'
         return value
     


### PR DESCRIPTION
因为在langchain中使用 ChatOpenAI(....version="v3.1"..)会报错，推测可能没有version字段，也有可能是我不会使用langchain。
如果是我使用方法有误的话，请忽略此PR。
使用方法
```python
client = ChatOpenAI(openai_api_base="http://xxxxx:8000/v1", model="spark-api-v3.1", max_tokens=1000, openai_api_key="sk-xxx")
```
model可选[spark-api-v3.1， spark-api-v2.1， spark-api-v1.1， vision]，默认与不是这四个的时候为spark-api-v3.1